### PR TITLE
Fix constraints for selected tables only

### DIFF
--- a/config/relationship_label.go
+++ b/config/relationship_label.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"github.com/KarnerTh/mermerd/util"
 	"regexp"
 	"strings"
 
@@ -35,8 +36,8 @@ func parseLabel(label string) (RelationshipLabel, error) {
 	}
 
 	return RelationshipLabel{
-		PkName: string(groups[1]),
-		FkName: string(groups[2]),
+		PkName: util.QuoteTableName(string(groups[1])),
+		FkName: util.QuoteTableName(string(groups[2])),
 		Label:  string(groups[3]),
 	}, nil
 }

--- a/diagram/diagram_util.go
+++ b/diagram/diagram_util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/KarnerTh/mermerd/util"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/KarnerTh/mermerd/config"
@@ -93,7 +95,10 @@ func shouldSkipConstraint(config config.MermerdConfig, tables []ErdTableData, co
 	}
 
 	// if config for all constraints is not set, only show constraints of selected tables
-	return !(tableNameInSlice(tables, constraint.PkTable) && tableNameInSlice(tables, constraint.FkTable))
+	// ensure that both tables (including the schema are in the list of tables)
+	pkTable := getTableName(config, database.TableDetail{Schema: constraint.PkSchema, Name: constraint.PkTable})
+	fkTable := getTableName(config, database.TableDetail{Schema: constraint.FkSchema, Name: constraint.FkTable})
+	return !(tableNameInSlice(tables, pkTable) && tableNameInSlice(tables, fkTable))
 }
 
 func getConstraintData(config config.MermerdConfig, labelMap RelationshipLabelMap, constraint database.ConstraintResult) ErdConstraintData {
@@ -124,10 +129,5 @@ func getTableName(config config.MermerdConfig, table database.TableDetail) strin
 	separator := config.SchemaPrefixSeparator()
 	name := fmt.Sprintf("%s%s%s", table.Schema, separator, table.Name)
 
-	// if fullstop is used the table name needs to be escaped with quote marks
-	if separator == "." {
-		return fmt.Sprintf("\"%s\"", name)
-	}
-
-	return name
+	return util.QuoteTableName(name)
 }

--- a/util/tablename_util.go
+++ b/util/tablename_util.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+const fullstopSeparator = "."
+
+// QuoteTableName quotes the table name if it contains a fullstop separator.
+func QuoteTableName(tableName string) string {
+	if !strings.Contains(tableName, fullstopSeparator) {
+		return tableName
+	}
+	return fmt.Sprintf("\"%s\"", tableName)
+}


### PR DESCRIPTION
When using a selection of  tables the constraints for those tables were not being found as the table names being searched for did not include the schema (together with the schemaPrefixSeparator)
Also if a fullstop was used as the schemaPrefixSeparator then the table names were quoted this was not being applied to the table names provided in the relationshipLabels configuration.  